### PR TITLE
Fix photo link on speaker.json

### DIFF
--- a/speakers.json
+++ b/speakers.json
@@ -171,7 +171,7 @@
         "Jetpack Compose"
       ],
       "bio": "10 yaşından beri yazılım geliştirmenin içerisinde yer alan öğrenci. Geleceğin Android GDE'si.",
-      "image": "https://ibb.co/vzMXnF8",
+      "image": "https://i.ibb.co/ZTb2DjC/IMG-4465.jpg",
       "email": "sarpremziaksu@gmail.com",
       "linkedin": "linkedin.com/in/sarpremziaksu",
       "twitter": "@sarpremziaksu ",


### PR DESCRIPTION
Should've added the raw image link at the beginning, please check for complications.